### PR TITLE
adding full liebendorfer deleptonization

### DIFF
--- a/inputs/progenitor.pin
+++ b/inputs/progenitor.pin
@@ -138,10 +138,11 @@ gam0_ceiling = 1.0e4
 # simple example for lightbulb case
 <radiation> 
 cfl = 0.5 
-method = cooling_function
+method 			= cooling_function
 do_lightbulb 	= true
-do_liebendorfer	= true
-do_gain_calc = false # defaults to false if not set
+do_delep		= true
+delep_method 	= liebendorfer_g15 # options are rho_fit, liebendorfer_g15 (default), and liebendorfer_n13
+do_gain_calc 	= false # defaults to false if not set
 
 <monopole_gr>
 enabled = true

--- a/scripts/python/stellar/progenitors.py
+++ b/scripts/python/stellar/progenitors.py
@@ -463,7 +463,7 @@ def save_ADM_profile( prof: np.ndarray, model_name: str, model_type: str, EOSPAT
 
     # creates a summary/info file with useful conversions and progenitor bounds
     if save_info:
-        make_info_file( rhoc, M0, R0, profile_conv, model_name, model_type, EOSPATH, eos_type, OUTPATH)
+        make_info_file( rhoc, M0, R0, prof_conv, model_name, model_type, EOSPATH, eos_type, OUTPATH)
 
     # saves the converted profile
     np.savetxt(

--- a/src/radiation/cooling_function.cpp
+++ b/src/radiation/cooling_function.cpp
@@ -234,8 +234,9 @@ TaskStatus CoolingFunctionCalculateFourForce(MeshData<Real> *rc, const double dt
               const Real lRho6 = lRho3 * lRho3;
               constexpr Real lRhoMin = LightBulb::LogRhoFit::LRHOMIN;
               constexpr Real lRhoMax = LightBulb::LogRhoFit::LRHOMAX;
-              bool do_densityregion = (lRhoMin <= lRho && lRho <= lRhoMax); // better name?
-              
+              bool do_densityregion =
+                  (lRhoMin <= lRho && lRho <= lRhoMax); // better name?
+
               constexpr Real Ye_beta = 0.27;
               constexpr Real Ye_floor = 0.05;
               constexpr Real a0 = LightBulb::LogRhoFit::A0;
@@ -247,8 +248,8 @@ TaskStatus CoolingFunctionCalculateFourForce(MeshData<Real> *rc, const double dt
               constexpr Real a6 = LightBulb::LogRhoFit::A6;
 
               if (do_densityregion) {
-                const Real Ye_fit = (a0 + a1 * lRho + a2 * lRho2 + a3 * lRho3 + a4 * lRho4 +
-                                    a5 * lRho5 + a6 * lRho6);
+                const Real Ye_fit = (a0 + a1 * lRho + a2 * lRho2 + a3 * lRho3 +
+                                     a4 * lRho4 + a5 * lRho5 + a6 * lRho6);
                 Real dYe = std::max(-0.05 * Ye, std::min(0.0, Ye_fit - Ye));
                 if (rho < 3.e8) { // impose plateau Ye for low densities
                   dYe = dYe * (rho - 1.e8) / 2.e8;
@@ -261,7 +262,8 @@ TaskStatus CoolingFunctionCalculateFourForce(MeshData<Real> *rc, const double dt
                 Jye = 0.0;
               }
 
-            } else if (delep_method == "liebendorfer_g15" || delep_method == "liebendorfer_n13") {
+            } else if (delep_method == "liebendorfer_g15" ||
+                       delep_method == "liebendorfer_n13") {
 
               Real lr1, y2;
               constexpr Real lr2 = LightBulb::Liebendorfer::LR2;
@@ -276,10 +278,10 @@ TaskStatus CoolingFunctionCalculateFourForce(MeshData<Real> *rc, const double dt
                 y2 = LightBulb::Liebendorfer::Y2_N13;
               }
 
-              const Real x = std::max( -1.0, std::min( 1.0, (2 * lRho - lr2 - lr1) / (lr2 - lr1) ));
+              const Real x =
+                  std::max(-1.0, std::min(1.0, (2 * lRho - lr2 - lr1) / (lr2 - lr1)));
               const Real xa = std::abs(x);
-              const Real Ye_fit = (0.5 * (y2 + y1)) + 
-                                  ((0.5 * x) * (y2 - y1)) +
+              const Real Ye_fit = (0.5 * (y2 + y1)) + ((0.5 * x) * (y2 - y1)) +
                                   (yc * (1 - xa + (4 * xa) * (xa - 0.5) * (xa - 1)));
 
               Real dYe = std::min(0.0, Ye_fit - Ye);

--- a/src/radiation/cooling_function.cpp
+++ b/src/radiation/cooling_function.cpp
@@ -177,7 +177,8 @@ TaskStatus CoolingFunctionCalculateFourForce(MeshData<Real> *rc, const double dt
       });
 
   // Light Bulb with Liebendorfer model
-  const bool do_liebendorfer = rad->Param<bool>("do_liebendorfer");
+  const bool do_delep = rad->Param<bool>("do_delep");
+  const std::string delep_method = rad->Param<std::string>("delep_method");
   const bool do_lightbulb = rad->Param<bool>("do_lightbulb");
   const bool do_gain_calc = rad->Param<bool>("do_gain_calc");
 
@@ -216,46 +217,75 @@ TaskStatus CoolingFunctionCalculateFourForce(MeshData<Real> *rc, const double dt
           Real Jye = 0.0;
           Real J;
           const Real lRho = std::log10(rho);
-          const Real lRho2 = lRho * lRho;
-          const Real lRho3 = lRho2 * lRho;
-          const Real lRho4 = lRho2 * lRho2;
-          const Real lRho5 = lRho4 * lRho;
-          const Real lRho6 = lRho3 * lRho3;
-          constexpr Real lRhoMin = LightBulb::Liebendorfer::LRHOMIN;
-          constexpr Real lRhoMax = LightBulb::Liebendorfer::LRHOMAX;
-          bool do_densityregion = (lRhoMin <= lRho && lRho <= lRhoMax); // better name?
           constexpr Real rnorm = LightBulb::HeatAndCool::RNORM;
           constexpr Real MeVToCGS = 1.16040892301e10;
           constexpr Real Tnorm = 2.0 * MeVToCGS;
 
           Real Ye = v(b, p::ye(), k, j, i);
 
-          if (do_liebendorfer) {
-            constexpr Real Ye_beta = 0.27;
-            constexpr Real Ye_floor = 0.05;
-            constexpr Real a0 = LightBulb::Liebendorfer::A0;
-            constexpr Real a1 = LightBulb::Liebendorfer::A1;
-            constexpr Real a2 = LightBulb::Liebendorfer::A2;
-            constexpr Real a3 = LightBulb::Liebendorfer::A3;
-            constexpr Real a4 = LightBulb::Liebendorfer::A4;
-            constexpr Real a5 = LightBulb::Liebendorfer::A5;
-            constexpr Real a6 = LightBulb::Liebendorfer::A6;
+          if (do_delep) {
 
-            if (do_densityregion) {
-              const Real Ye_fit = (a0 + a1 * lRho + a2 * lRho2 + a3 * lRho3 + a4 * lRho4 +
-                                   a5 * lRho5 + a6 * lRho6);
-              Real dYe = std::max(-0.05 * Ye, std::min(0.0, Ye_fit - Ye));
-              if (rho < 3.e8) { // impose plateau Ye for low densities
-                dYe = dYe * (rho - 1.e8) / 2.e8;
+            if (delep_method == "rho_fit") {
+
+              const Real lRho2 = lRho * lRho;
+              const Real lRho3 = lRho2 * lRho;
+              const Real lRho4 = lRho2 * lRho2;
+              const Real lRho5 = lRho4 * lRho;
+              const Real lRho6 = lRho3 * lRho3;
+              constexpr Real lRhoMin = LightBulb::LogRhoFit::LRHOMIN;
+              constexpr Real lRhoMax = LightBulb::LogRhoFit::LRHOMAX;
+              bool do_densityregion = (lRhoMin <= lRho && lRho <= lRhoMax); // better name?
+              
+              constexpr Real Ye_beta = 0.27;
+              constexpr Real Ye_floor = 0.05;
+              constexpr Real a0 = LightBulb::LogRhoFit::A0;
+              constexpr Real a1 = LightBulb::LogRhoFit::A1;
+              constexpr Real a2 = LightBulb::LogRhoFit::A2;
+              constexpr Real a3 = LightBulb::LogRhoFit::A3;
+              constexpr Real a4 = LightBulb::LogRhoFit::A4;
+              constexpr Real a5 = LightBulb::LogRhoFit::A5;
+              constexpr Real a6 = LightBulb::LogRhoFit::A6;
+
+              if (do_densityregion) {
+                const Real Ye_fit = (a0 + a1 * lRho + a2 * lRho2 + a3 * lRho3 + a4 * lRho4 +
+                                    a5 * lRho5 + a6 * lRho6);
+                Real dYe = std::max(-0.05 * Ye, std::min(0.0, Ye_fit - Ye));
+                if (rho < 3.e8) { // impose plateau Ye for low densities
+                  dYe = dYe * (rho - 1.e8) / 2.e8;
+                }
+                if (Ye < Ye_beta) {
+                  dYe = 0;
+                }
+                Jye = dYe / dt * cdensity;
+              } else {
+                Jye = 0.0;
               }
-              if (Ye < Ye_beta) {
-                dYe = 0;
+
+            } else if (delep_method == "g15" || delep_method == "n13") {
+
+              Real lr1, y2;
+              constexpr Real lr2 = LightBulb::Liebendorfer::LR2;
+              constexpr Real y1 = LightBulb::Liebendorfer::Y1;
+              constexpr Real yc = LightBulb::Liebendorfer::YC;
+
+              if (delep_method == "g15") {
+                lr1 = LightBulb::Liebendorfer::LR1_G15;
+                y2 = LightBulb::Liebendorfer::Y2_G15;
+              } else {
+                lr1 = LightBulb::Liebendorfer::LR1_N13;
+                y2 = LightBulb::Liebendorfer::Y2_N13;
               }
+
+              const Real x = std::max( -1, std::min( 1, (2 * lRho - lr2 - lr1) / (lr2 - lr1) ));
+              const Real xa = std::abs(x);
+              const Real Ye_fit = (0.5 * (y2 + y1)) + 
+                                  ((0.5 * x) * (y2 - y1)) +
+                                  (yc * (1 - xa + (4 * xa) * (xa - 0.5) * (xa - 1)));
+
+              Real dYe = std::min(0.0, Ye_fit - Ye);
               Jye = dYe / dt * cdensity;
-            } else {
-              Jye = 0.0;
-            }
           }
+
           Real heat;
           Real cool;
           const Real tau = v(b, iv::tau(), k, j, i);

--- a/src/radiation/cooling_function.cpp
+++ b/src/radiation/cooling_function.cpp
@@ -261,14 +261,14 @@ TaskStatus CoolingFunctionCalculateFourForce(MeshData<Real> *rc, const double dt
                 Jye = 0.0;
               }
 
-            } else if (delep_method == "g15" || delep_method == "n13") {
+            } else if (delep_method == "liebendorfer_g15" || delep_method == "liebendorfer_n13") {
 
               Real lr1, y2;
               constexpr Real lr2 = LightBulb::Liebendorfer::LR2;
               constexpr Real y1 = LightBulb::Liebendorfer::Y1;
               constexpr Real yc = LightBulb::Liebendorfer::YC;
 
-              if (delep_method == "g15") {
+              if (delep_method == "liebendorfer_g15") {
                 lr1 = LightBulb::Liebendorfer::LR1_G15;
                 y2 = LightBulb::Liebendorfer::Y2_G15;
               } else {
@@ -276,7 +276,7 @@ TaskStatus CoolingFunctionCalculateFourForce(MeshData<Real> *rc, const double dt
                 y2 = LightBulb::Liebendorfer::Y2_N13;
               }
 
-              const Real x = std::max( -1, std::min( 1, (2 * lRho - lr2 - lr1) / (lr2 - lr1) ));
+              const Real x = std::max( -1.0, std::min( 1.0, (2 * lRho - lr2 - lr1) / (lr2 - lr1) ));
               const Real xa = std::abs(x);
               const Real Ye_fit = (0.5 * (y2 + y1)) + 
                                   ((0.5 * x) * (y2 - y1)) +
@@ -284,6 +284,7 @@ TaskStatus CoolingFunctionCalculateFourForce(MeshData<Real> *rc, const double dt
 
               Real dYe = std::min(0.0, Ye_fit - Ye);
               Jye = dYe / dt * cdensity;
+            }
           }
 
           Real heat;

--- a/src/radiation/light_bulb_constants.hpp
+++ b/src/radiation/light_bulb_constants.hpp
@@ -30,8 +30,8 @@ constexpr Real LRHOMAX = 13.;
 
 namespace Liebendorfer {
 // log rho parameters
-constexpr Real LR1_G15 = std::log10(2.0e7);
-constexpr Real LR1_N13 = std::log10(3.0e7);
+constexpr Real LR1_G15 = std::log10(3.0e7);
+constexpr Real LR1_N13 = std::log10(2.0e7);
 constexpr Real LR2 = std::log10(2.0e13);
 // ye parameters
 constexpr Real Y1 = 0.5;

--- a/src/radiation/light_bulb_constants.hpp
+++ b/src/radiation/light_bulb_constants.hpp
@@ -15,7 +15,8 @@
 #define LIGHT_BULB_CONSTANTS_HPP_
 
 namespace LightBulb {
-namespace Liebendorfer {
+
+namespace LogRhoFit {
 constexpr Real A0 = 2.120282875020e+02;
 constexpr Real A1 = -1.279083733386e+02;
 constexpr Real A2 = 3.199984467460e+01;
@@ -25,6 +26,18 @@ constexpr Real A5 = -1.226365543366e-02;
 constexpr Real A6 = 1.983947360151e-04;
 constexpr Real LRHOMIN = 8.;
 constexpr Real LRHOMAX = 13.;
+} // namespace LogRhoFit
+
+namespace Liebendorfer {
+// log rho parameters
+constexpr Real LR1_G15 = std::log10(2.0e7);
+constexpr Real LR1_N13 = std::log10(3.0e7);
+constexpr Real LR2 = std::log10(2.0e13);
+// ye parameters
+constexpr Real Y1 = 0.5;
+constexpr Real Y2_G15 = 0.278;
+constexpr Real Y2_N13 = 0.285;
+constexpr Real YC = 0.035;
 } // namespace Liebendorfer
 
 namespace HeatAndCool {

--- a/src/radiation/radiation.cpp
+++ b/src/radiation/radiation.cpp
@@ -131,12 +131,14 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   if (method == "cooling_function") {
     const bool do_delep = pin->GetOrAddBoolean("radiation", "do_delep", true);
 
-    // adding an option to switch between deleptonization prescriptions 
+    // adding an option to switch between deleptonization prescriptions
     // e.g. 6th order density fit, liebendorfer (g15 or n13)
-    const std::string delep_method = pin->GetOrAddString( "radiation", "delep_method", "liebendorfer_g15");
+    const std::string delep_method =
+        pin->GetOrAddString("radiation", "delep_method", "liebendorfer_g15");
 
     // error checks and handling
-    std::set<std::string> known_delep_methods = {"rho_fit", "liebendorfer_g15", "liebendorfer_n13"};
+    std::set<std::string> known_delep_methods = {"rho_fit", "liebendorfer_g15",
+                                                 "liebendorfer_n13"};
     if (!known_delep_methods.count(delep_method)) {
       std::stringstream msg;
       msg << "Deleptonization method \"" << delep_method << "\" not recognized!";

--- a/src/radiation/radiation.cpp
+++ b/src/radiation/radiation.cpp
@@ -129,11 +129,25 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
 
   bool do_lightbulb = false;
   if (method == "cooling_function") {
-    const bool do_liebendorfer =
-        pin->GetOrAddBoolean("radiation", "do_liebendorfer", false);
+    const bool do_delep = pin->GetOrAddBoolean("radiation", "do_delep", true);
+
+    // adding an option to switch between deleptonization prescriptions 
+    // e.g. 6th order density fit, liebendorfer (g15 or n13)
+    const std::string delep_method = pin->GetOrAddString( "radiation", "delep_method", "g15");
+
+    // error checks and handling
+    std::set<std::string> known_delep_methods = {"rho_fit", "g15", "n13"};
+    if (!known_delep_methods.count(delep_method)) {
+      std::stringstream msg;
+      msg << "Deleptonization method \"" << method << "\" not recognized!";
+      PARTHENON_THROW(msg);
+    }
+
     bool do_lightbulb = pin->GetOrAddBoolean("radiation", "do_lightbulb", false);
     const Real lum = pin->GetOrAddReal("radiation", "lum", 4.0);
-    params.Add("do_liebendorfer", do_liebendorfer);
+
+    params.Add("do_delep", do_delep);
+    params.Add("delep_method", delep_method);
     params.Add("do_lightbulb", do_lightbulb);
     params.Add("lum", lum);
     if (do_lightbulb) {

--- a/src/radiation/radiation.cpp
+++ b/src/radiation/radiation.cpp
@@ -133,13 +133,13 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
 
     // adding an option to switch between deleptonization prescriptions 
     // e.g. 6th order density fit, liebendorfer (g15 or n13)
-    const std::string delep_method = pin->GetOrAddString( "radiation", "delep_method", "g15");
+    const std::string delep_method = pin->GetOrAddString( "radiation", "delep_method", "liebendorfer_g15");
 
     // error checks and handling
-    std::set<std::string> known_delep_methods = {"rho_fit", "g15", "n13"};
+    std::set<std::string> known_delep_methods = {"rho_fit", "liebendorfer_g15", "liebendorfer_n13"};
     if (!known_delep_methods.count(delep_method)) {
       std::stringstream msg;
-      msg << "Deleptonization method \"" << method << "\" not recognized!";
+      msg << "Deleptonization method \"" << delep_method << "\" not recognized!";
       PARTHENON_THROW(msg);
     }
 


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

After a bit of examination with the homologous collapse tests detailed in #246, I noticed that the deleptonization prescription implemented in the current code base only used the [Liebendörfer 2005](https://ui.adsabs.harvard.edu/abs/2005ApJ...633.1042L/abstract) method for updating Ye (i.e. how we do the final calculation of dYe), but with a sixth-order polynomial fit to a pre-calculated fit of Ye evolution based on log density. See fig. 1 below for an example of how this changes initial Ye evolution.

I've added some tweaks to how we handle deleptonization in the input decks (e.g. `do_delep` instead of `do_liebendorfer`, with appropriate method selection and error handling), as well as the full deleptonization prescriptions (method and fits) provided in Liebendörfer (G15 and N13). I'll include more figures for the homologous and progenitor tests run with the new delep methods shortly.

As a tiny bonus, there's also a typo fix included for a single variable name I missed in #245.

---

**Fig. 1.** Example implementation of the current log-density deleptonization fit included in phoebus, in comparison to the two prescriptions from Liebendörfer. Note that the changes in Ye here have greater amplitiude than the final phoebus implementation-- we update with dYe/dt in-code, where this figure just shows dYe.

<img width="979" height="856" alt="Unknown-7" src="https://github.com/user-attachments/assets/da0c869c-edca-4cef-bd1c-7c3eb0bd1525" />

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by calling `scripts/bash/format.sh`.
- [x] Explain what you did.
- [x] Make any necessary changes to the documentation.
