### PR TITLE
also adding liebendorfer entropy 

### DIFF
--- a/inputs/progenitor.pin
+++ b/inputs/progenitor.pin
@@ -140,8 +140,13 @@ gam0_ceiling = 1.0e4
 cfl = 0.5 
 method 			= cooling_function
 do_lightbulb 	= true
+
 do_delep		= true
 delep_method 	= liebendorfer_g15 # options are rho_fit, liebendorfer_g15 (default), and liebendorfer_n13
+
+do_delep_entropy = true # defaults to false if not set
+delep_Enu      	= 10.0 # default value from liebendorfer, in MeV
+
 do_gain_calc 	= false # defaults to false if not set
 
 <monopole_gr>

--- a/inputs/progenitor.pin
+++ b/inputs/progenitor.pin
@@ -145,7 +145,8 @@ do_delep		= true
 delep_method 	= liebendorfer_g15 # options are rho_fit, liebendorfer_g15 (default), and liebendorfer_n13
 
 do_delep_entropy = true # defaults to false if not set
-delep_Enu      	= 10.0 # default value from liebendorfer, in MeV
+delep_entropy_Enu = 10.0 # default value from liebendorfer, in MeV
+delep_entropy_rho = 2.0e12 # default value from liebendorfer, in g/cm^3
 
 do_gain_calc 	= false # defaults to false if not set
 

--- a/src/phoebus_utils/adiabats.hpp
+++ b/src/phoebus_utils/adiabats.hpp
@@ -108,6 +108,31 @@ inline void ComputeAdiabats(DataBox lrho, DataBox temp, const EOS &eos, const Re
 }
 
 /**
+ * Given Ye and a target entropy, compute density and temperature of constant entropy 
+ * (for singular values of rho, T only).
+ **/
+template <typename EOS>
+inline void ComputeAdiabats(Real lrho, Real temp, const EOS &eos, const Real Ye,
+                            const Real S0, const Real T_min, const Real T_max) {
+
+  const Real guess0 = (T_max - T_min) / 2.0;
+  const Real epsilon = std::numeric_limits<Real>::epsilon();
+
+  const Real Rho = std::pow(10.0, lrho(i));
+  Real lambda[2];
+  lambda[0] = Ye;
+
+  auto target = [&](const Real T) {
+    return eos.EntropyFromDensityTemperature(Rho, T, lambda) - S0;
+  };
+
+  const Real guess = guess0;
+  root_find::RootFind root_find;
+  temp(i) = root_find.regula_falsi(target, T_min, T_max, epsilon * guess, guess);
+
+}
+
+/**
  * Find the minimum enthalpy along an adiabat as computed above
  **/
 template <typename EOS>

--- a/src/phoebus_utils/adiabats.hpp
+++ b/src/phoebus_utils/adiabats.hpp
@@ -108,31 +108,6 @@ inline void ComputeAdiabats(DataBox lrho, DataBox temp, const EOS &eos, const Re
 }
 
 /**
- * Given Ye and a target entropy, compute density and temperature of constant entropy 
- * (for singular values of rho, T only).
- **/
-template <typename EOS>
-inline void ComputeAdiabats(Real lrho, Real temp, const EOS &eos, const Real Ye,
-                            const Real S0, const Real T_min, const Real T_max) {
-
-  const Real guess0 = (T_max - T_min) / 2.0;
-  const Real epsilon = std::numeric_limits<Real>::epsilon();
-
-  const Real Rho = std::pow(10.0, lrho(i));
-  Real lambda[2];
-  lambda[0] = Ye;
-
-  auto target = [&](const Real T) {
-    return eos.EntropyFromDensityTemperature(Rho, T, lambda) - S0;
-  };
-
-  const Real guess = guess0;
-  root_find::RootFind root_find;
-  temp(i) = root_find.regula_falsi(target, T_min, T_max, epsilon * guess, guess);
-
-}
-
-/**
  * Find the minimum enthalpy along an adiabat as computed above
  **/
 template <typename EOS>

--- a/src/radiation/cooling_function.cpp
+++ b/src/radiation/cooling_function.cpp
@@ -306,8 +306,10 @@ TaskStatus CoolingFunctionCalculateFourForce(MeshData<Real> *rc, const double dt
               Real garbage;
 
               // all our const values
-              const Real E_nu = rad->Param<Real>("delep_Enu") *
+              const Real E_nu = rad->Param<Real>("delep_entropy_Enu") *
                                 MeVToErg; // escape energy param., in MeV
+              const Real rho_trap =
+                  rad->Param<Real>("delep_entropy_rho"); // trapping density, g/cm^3
               const Real T0 =
                   v(b, p::temperature(), k, j, i) * temperature_conversion_factor;
               const Real rho0 = rho;
@@ -325,7 +327,7 @@ TaskStatus CoolingFunctionCalculateFourForce(MeshData<Real> *rc, const double dt
 
               // regime criterion: if neutrino potential less than escape energy or
               // density too high, we don't change entropy.
-              if (mu_nu < E_nu || rho0 >= 2.0e12) {
+              if (mu_nu < E_nu || rho0 >= rho_trap) {
 
                 S0 = eos_sc.EntropyFromDensityTemperature(rho, T0, lambda);
                 dS = robust::ratio(-dYe * (mu_e - mu_n + mu_p - E_nu), T0);

--- a/src/radiation/cooling_function.cpp
+++ b/src/radiation/cooling_function.cpp
@@ -15,6 +15,7 @@
 #include "geometry/geometry_utils.hpp"
 #include "light_bulb_constants.hpp"
 #include "phoebus_utils/variables.hpp"
+#include "phoebus_utils/adiabats.hpp"
 #include "radiation.hpp"
 #include <algorithm>
 #include <interface/sparse_pack.hpp>
@@ -178,6 +179,7 @@ TaskStatus CoolingFunctionCalculateFourForce(MeshData<Real> *rc, const double dt
 
   // Light Bulb with Liebendorfer model
   const bool do_delep = rad->Param<bool>("do_delep");
+  const bool do_delep = rad->Param<bool>("do_delep_entropy");
   const std::string delep_method = rad->Param<std::string>("delep_method");
   const bool do_lightbulb = rad->Param<bool>("do_lightbulb");
   const bool do_gain_calc = rad->Param<bool>("do_gain_calc");
@@ -222,6 +224,8 @@ TaskStatus CoolingFunctionCalculateFourForce(MeshData<Real> *rc, const double dt
           constexpr Real Tnorm = 2.0 * MeVToCGS;
 
           Real Ye = v(b, p::ye(), k, j, i);
+          Real lambda[2];
+          lambda[0] = Ye;
 
           if (do_delep) {
 
@@ -287,6 +291,25 @@ TaskStatus CoolingFunctionCalculateFourForce(MeshData<Real> *rc, const double dt
               Real dYe = std::min(0.0, Ye_fit - Ye);
               Jye = dYe / dt * cdensity;
             }
+
+            // now we add the entropy update (eq. 5, liebendorfer 2005)
+            if ( do_delep_entropy ) {
+
+              Real dS, S0;
+              Real drho, dT;
+              Real mu_e, mu_p, mu_n; // chemical potentials, we'll get from singularity
+              Real garbage;
+              const Real E_esc = rad->Param<Real>("E_esc"); // escape energy param., in MeV
+
+              eos_sc.ChemicalPotentialsFromDensityTemperature(rho, v(b, p::temperature(), k, j, i) * temperature_conversion_factor, mu_e, mu_n, mu_p, garbage, garbage, lambda );
+
+              S0 = eos_sc.EntropyFromDensityTemperature(rho, v(b, p::temperature(), k, j, i) * temperature_conversion_factor, lambda);
+              // TODO: check the units on below...
+              dS = robust::ratio(-dYe * (mu_e - mu_n + mu_p - E_esc), v(b, p::temperature(), k, j, i) * temperature_conversion_factor );
+              
+              // TODO: add implementation of ~ComputeAdiabats here, need to adjust in phoebus_utils/adiabats.hpp...
+              // update density, temperature primitives (?)
+            }
           }
 
           Real heat;
@@ -295,8 +318,7 @@ TaskStatus CoolingFunctionCalculateFourForce(MeshData<Real> *rc, const double dt
           const Real hfac = LightBulb::HeatAndCool::HFAC * lum;
           const Real cfac = LightBulb::HeatAndCool::CFAC;
           Real Xa, Xh, Xn, Xp, Abar, Zbar;
-          Real lambda[2];
-          lambda[0] = Ye;
+
           eos_sc.MassFractionsFromDensityTemperature(
               rho, v(b, p::temperature(), k, j, i) * temperature_conversion_factor, Xa,
               Xh, Xn, Xp, Abar, Zbar, lambda);

--- a/src/radiation/cooling_function.cpp
+++ b/src/radiation/cooling_function.cpp
@@ -344,7 +344,6 @@ TaskStatus CoolingFunctionCalculateFourForce(MeshData<Real> *rc, const double dt
 
                 // final temperature update - should this be done after lightbulb?
                 v(b, p::temperature(), k, j, i) = dT / temperature_conversion_factor;
-                printf("dS:\t%5.8e\t\tdT:\t%5.8e\n", dS, dT - T0);
               }
             }
           }

--- a/src/radiation/cooling_function.cpp
+++ b/src/radiation/cooling_function.cpp
@@ -220,8 +220,10 @@ TaskStatus CoolingFunctionCalculateFourForce(MeshData<Real> *rc, const double dt
           Real J;
           const Real lRho = std::log10(rho);
           constexpr Real rnorm = LightBulb::HeatAndCool::RNORM;
-          constexpr Real MeVToCGS = 1.16040892301e10;
-          constexpr Real Tnorm = 2.0 * MeVToCGS;
+          constexpr Real MeVToK = 1.16040892301e10;
+          constexpr Real Tnorm = 2.0 * MeVToK;
+
+          constexpr Real MeVToErg = 1.60217663399e-6;
 
           Real Ye = v(b, p::ye(), k, j, i);
           Real lambda[2];
@@ -295,42 +297,55 @@ TaskStatus CoolingFunctionCalculateFourForce(MeshData<Real> *rc, const double dt
             }
 
             // now we add the entropy update (eq. 5, liebendorfer 2005)
-            if (do_delep_entropy) {
+            if (do_delep_entropy && dYe != 0.0) {
 
-              Real dS, S0;           // entropies
-              Real dT;               // temperature to update
-              Real mu_e, mu_p, mu_n; // chemical potentials, we'll get from singularity
+              Real dS, S0; // entropies
+              Real dT;     // temperature to update
+              Real mu_e, mu_p, mu_n,
+                  mu_nu; // chemical potentials, we'll get from singularity
               Real garbage;
 
               // all our const values
-              const Real E_esc =
-                  rad->Param<Real>("E_esc"); // escape energy param., in MeV
+              const Real E_nu = rad->Param<Real>("delep_Enu") *
+                                MeVToErg; // escape energy param., in MeV
               const Real T0 =
                   v(b, p::temperature(), k, j, i) * temperature_conversion_factor;
               const Real rho0 = rho;
               const Real epsilon = std::numeric_limits<Real>::epsilon();
 
               eos_sc.ChemicalPotentialsFromDensityTemperature(rho, T0, mu_e, mu_n, mu_p,
-                                                              garbage, garbage, lambda);
+                                                              garbage, mu_nu, lambda);
 
-              S0 = eos_sc.EntropyFromDensityTemperature(rho, T0, lambda);
-              // TODO: check the units on below...
-              dS = robust::ratio(-dYe * (mu_e - mu_n + mu_p - E_esc), T0);
+              // we need to convert all of our potentials, Enu (MeV -> erg)
+              // assuming entropy has units of erg/g/K
+              mu_e *= MeVToErg;
+              mu_p *= MeVToErg;
+              mu_n *= MeVToErg;
+              mu_nu *= MeVToErg;
 
-              // now we find the change in temperature and update, since we don't actually
-              // track entropy we'll use a root find method similar to that in
-              // adiabats.hpp:ComputeAdiabats
-              auto target = [&](const Real T) {
-                return eos_sc.EntropyFromDensityTemperature(rho0, T, lambda) - (S0 + dS);
-              };
+              // regime criterion: if neutrino potential less than escape energy or
+              // density too high, we don't change entropy.
+              if (mu_nu < E_nu || rho0 >= 2.0e12) {
 
-              root_find::RootFind root_find;
-              dT = root_find.regula_falsi(target, eos_sc.TMin(), eos_sc.TMax(),
-                                          epsilon * T0, T0);
+                S0 = eos_sc.EntropyFromDensityTemperature(rho, T0, lambda);
+                dS = robust::ratio(-dYe * (mu_e - mu_n + mu_p - E_nu), T0);
 
-              // final temperature update - should this be done after lightbulb?
-              v(b, p::temperature(), k, j, i) = dT / temperature_conversion_factor;
-              printf("S + dS:\t%5.8e\t\tdT:\t%5.8e\n", S0 + dS, dT);
+                // now we find the change in temperature and update, since we don't
+                // actually track entropy we'll use a root find method similar to that in
+                // adiabats.hpp:ComputeAdiabats
+                auto target = [&](const Real T) {
+                  return eos_sc.EntropyFromDensityTemperature(rho0, T, lambda) -
+                         (S0 + dS);
+                };
+
+                root_find::RootFind root_find;
+                dT = root_find.regula_falsi(target, eos_sc.TMin(), eos_sc.TMax(),
+                                            epsilon * T0, T0);
+
+                // final temperature update - should this be done after lightbulb?
+                v(b, p::temperature(), k, j, i) = dT / temperature_conversion_factor;
+                printf("dS:\t%5.8e\t\tdT:\t%5.8e\n", dS, dT - T0);
+              }
             }
           }
 

--- a/src/radiation/cooling_function.cpp
+++ b/src/radiation/cooling_function.cpp
@@ -14,8 +14,8 @@
 #include "geometry/geometry.hpp"
 #include "geometry/geometry_utils.hpp"
 #include "light_bulb_constants.hpp"
+#include "phoebus_utils/root_find.hpp"
 #include "phoebus_utils/variables.hpp"
-#include "phoebus_utils/adiabats.hpp"
 #include "radiation.hpp"
 #include <algorithm>
 #include <interface/sparse_pack.hpp>
@@ -179,7 +179,7 @@ TaskStatus CoolingFunctionCalculateFourForce(MeshData<Real> *rc, const double dt
 
   // Light Bulb with Liebendorfer model
   const bool do_delep = rad->Param<bool>("do_delep");
-  const bool do_delep = rad->Param<bool>("do_delep_entropy");
+  const bool do_delep_entropy = rad->Param<bool>("do_delep_entropy");
   const std::string delep_method = rad->Param<std::string>("delep_method");
   const bool do_lightbulb = rad->Param<bool>("do_lightbulb");
   const bool do_gain_calc = rad->Param<bool>("do_gain_calc");
@@ -229,6 +229,8 @@ TaskStatus CoolingFunctionCalculateFourForce(MeshData<Real> *rc, const double dt
 
           if (do_delep) {
 
+            Real dYe;
+
             if (delep_method == "rho_fit") {
 
               const Real lRho2 = lRho * lRho;
@@ -254,7 +256,7 @@ TaskStatus CoolingFunctionCalculateFourForce(MeshData<Real> *rc, const double dt
               if (do_densityregion) {
                 const Real Ye_fit = (a0 + a1 * lRho + a2 * lRho2 + a3 * lRho3 +
                                      a4 * lRho4 + a5 * lRho5 + a6 * lRho6);
-                Real dYe = std::max(-0.05 * Ye, std::min(0.0, Ye_fit - Ye));
+                dYe = std::max(-0.05 * Ye, std::min(0.0, Ye_fit - Ye));
                 if (rho < 3.e8) { // impose plateau Ye for low densities
                   dYe = dYe * (rho - 1.e8) / 2.e8;
                 }
@@ -288,27 +290,47 @@ TaskStatus CoolingFunctionCalculateFourForce(MeshData<Real> *rc, const double dt
               const Real Ye_fit = (0.5 * (y2 + y1)) + ((0.5 * x) * (y2 - y1)) +
                                   (yc * (1 - xa + (4 * xa) * (xa - 0.5) * (xa - 1)));
 
-              Real dYe = std::min(0.0, Ye_fit - Ye);
+              dYe = std::min(0.0, Ye_fit - Ye);
               Jye = dYe / dt * cdensity;
             }
 
             // now we add the entropy update (eq. 5, liebendorfer 2005)
-            if ( do_delep_entropy ) {
+            if (do_delep_entropy) {
 
-              Real dS, S0;
-              Real drho, dT;
+              Real dS, S0;           // entropies
+              Real dT;               // temperature to update
               Real mu_e, mu_p, mu_n; // chemical potentials, we'll get from singularity
               Real garbage;
-              const Real E_esc = rad->Param<Real>("E_esc"); // escape energy param., in MeV
 
-              eos_sc.ChemicalPotentialsFromDensityTemperature(rho, v(b, p::temperature(), k, j, i) * temperature_conversion_factor, mu_e, mu_n, mu_p, garbage, garbage, lambda );
+              // all our const values
+              const Real E_esc =
+                  rad->Param<Real>("E_esc"); // escape energy param., in MeV
+              const Real T0 =
+                  v(b, p::temperature(), k, j, i) * temperature_conversion_factor;
+              const Real rho0 = rho;
+              const Real epsilon = std::numeric_limits<Real>::epsilon();
 
-              S0 = eos_sc.EntropyFromDensityTemperature(rho, v(b, p::temperature(), k, j, i) * temperature_conversion_factor, lambda);
+              eos_sc.ChemicalPotentialsFromDensityTemperature(rho, T0, mu_e, mu_n, mu_p,
+                                                              garbage, garbage, lambda);
+
+              S0 = eos_sc.EntropyFromDensityTemperature(rho, T0, lambda);
               // TODO: check the units on below...
-              dS = robust::ratio(-dYe * (mu_e - mu_n + mu_p - E_esc), v(b, p::temperature(), k, j, i) * temperature_conversion_factor );
-              
-              // TODO: add implementation of ~ComputeAdiabats here, need to adjust in phoebus_utils/adiabats.hpp...
-              // update density, temperature primitives (?)
+              dS = robust::ratio(-dYe * (mu_e - mu_n + mu_p - E_esc), T0);
+
+              // now we find the change in temperature and update, since we don't actually
+              // track entropy we'll use a root find method similar to that in
+              // adiabats.hpp:ComputeAdiabats
+              auto target = [&](const Real T) {
+                return eos_sc.EntropyFromDensityTemperature(rho0, T, lambda) - (S0 + dS);
+              };
+
+              root_find::RootFind root_find;
+              dT = root_find.regula_falsi(target, eos_sc.TMin(), eos_sc.TMax(),
+                                          epsilon * T0, T0);
+
+              // final temperature update - should this be done after lightbulb?
+              v(b, p::temperature(), k, j, i) = dT / temperature_conversion_factor;
+              printf("S + dS:\t%5.8e\t\tdT:\t%5.8e\n", S0 + dS, dT);
             }
           }
 

--- a/src/radiation/radiation.cpp
+++ b/src/radiation/radiation.cpp
@@ -133,7 +133,9 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
     // enables liebendorfer entropy evolution (through drho, dT)
     const bool do_delep_entropy =
         pin->GetOrAddBoolean("radiation", "do_delep_entropy", false);
-    const Real E_nu = pin->GetOrAddReal("radiation", "delep_Enu", 10.0); // MeV
+    const Real E_nu = pin->GetOrAddReal("radiation", "delep_entroopy_Enu", 10.0); // MeV
+    const Real rho_trap =
+        pin->GetOrAddReal("radiation", "delep_entropy_rho", 2.0e12); // g/cm^3
 
     // adding an option to switch between deleptonization prescriptions
     // e.g. 6th order density fit, liebendorfer (g15 or n13)
@@ -154,7 +156,8 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
 
     params.Add("do_delep", do_delep);
     params.Add("do_delep_entropy", do_delep_entropy);
-    params.Add("delep_Enu", E_nu);
+    params.Add("delep_entropy_Enu", E_nu);
+    params.Add("delep_entropy_rho", rho_trap);
     params.Add("delep_method", delep_method);
     params.Add("do_lightbulb", do_lightbulb);
     params.Add("lum", lum);

--- a/src/radiation/radiation.cpp
+++ b/src/radiation/radiation.cpp
@@ -131,8 +131,9 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   if (method == "cooling_function") {
     const bool do_delep = pin->GetOrAddBoolean("radiation", "do_delep", true);
     // enables liebendorfer entropy evolution (through drho, dT)
-    const bool do_delep_entropy = GetOrAddBoolean("radiation", "do_delep_entropy", true);
-    const Real E_esc = GetOrAddReal("radiation", "E_esc", 10.0); // MeV
+    const bool do_delep_entropy =
+        pin->GetOrAddBoolean("radiation", "do_delep_entropy", true);
+    const Real E_esc = pin->GetOrAddReal("radiation", "E_esc", 10.0); // MeV
 
     // adding an option to switch between deleptonization prescriptions
     // e.g. 6th order density fit, liebendorfer (g15 or n13)

--- a/src/radiation/radiation.cpp
+++ b/src/radiation/radiation.cpp
@@ -133,7 +133,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
     // enables liebendorfer entropy evolution (through drho, dT)
     const bool do_delep_entropy =
         pin->GetOrAddBoolean("radiation", "do_delep_entropy", true);
-    const Real E_esc = pin->GetOrAddReal("radiation", "E_esc", 10.0); // MeV
+    const Real E_nu = pin->GetOrAddReal("radiation", "delep_Enu", 10.0); // MeV
 
     // adding an option to switch between deleptonization prescriptions
     // e.g. 6th order density fit, liebendorfer (g15 or n13)
@@ -154,7 +154,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
 
     params.Add("do_delep", do_delep);
     params.Add("do_delep_entropy", do_delep_entropy);
-    params.Add("E_esc", E_esc);
+    params.Add("delep_Enu", E_nu);
     params.Add("delep_method", delep_method);
     params.Add("do_lightbulb", do_lightbulb);
     params.Add("lum", lum);

--- a/src/radiation/radiation.cpp
+++ b/src/radiation/radiation.cpp
@@ -133,7 +133,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
     // enables liebendorfer entropy evolution (through drho, dT)
     const bool do_delep_entropy =
         pin->GetOrAddBoolean("radiation", "do_delep_entropy", false);
-    const Real E_nu = pin->GetOrAddReal("radiation", "delep_entroopy_Enu", 10.0); // MeV
+    const Real E_nu = pin->GetOrAddReal("radiation", "delep_entropy_Enu", 10.0); // MeV
     const Real rho_trap =
         pin->GetOrAddReal("radiation", "delep_entropy_rho", 2.0e12); // g/cm^3
 

--- a/src/radiation/radiation.cpp
+++ b/src/radiation/radiation.cpp
@@ -132,7 +132,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
     const bool do_delep = pin->GetOrAddBoolean("radiation", "do_delep", true);
     // enables liebendorfer entropy evolution (through drho, dT)
     const bool do_delep_entropy =
-        pin->GetOrAddBoolean("radiation", "do_delep_entropy", true);
+        pin->GetOrAddBoolean("radiation", "do_delep_entropy", false);
     const Real E_nu = pin->GetOrAddReal("radiation", "delep_Enu", 10.0); // MeV
 
     // adding an option to switch between deleptonization prescriptions

--- a/src/radiation/radiation.cpp
+++ b/src/radiation/radiation.cpp
@@ -130,6 +130,9 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   bool do_lightbulb = false;
   if (method == "cooling_function") {
     const bool do_delep = pin->GetOrAddBoolean("radiation", "do_delep", true);
+    // enables liebendorfer entropy evolution (through drho, dT)
+    const bool do_delep_entropy = GetOrAddBoolean("radiation", "do_delep_entropy", true);
+    const Real E_esc = GetOrAddReal("radiation", "E_esc", 10.0); // MeV
 
     // adding an option to switch between deleptonization prescriptions
     // e.g. 6th order density fit, liebendorfer (g15 or n13)
@@ -149,6 +152,8 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
     const Real lum = pin->GetOrAddReal("radiation", "lum", 4.0);
 
     params.Add("do_delep", do_delep);
+    params.Add("do_delep_entropy", do_delep_entropy);
+    params.Add("E_esc", E_esc);
     params.Add("delep_method", delep_method);
     params.Add("do_lightbulb", do_lightbulb);
     params.Add("lum", lum);


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in ideal gas EOS.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

After conversation with @carlnotsagan and @AstroBarker, it was suggested that we consider adding the entropy evolution that's implemented in [Liebendörfer 2005](https://ui.adsabs.harvard.edu/abs/2005ApJ...633.1042L/abstract) (**ref.** eq. 5 for the full prescription) in addition to the $Y_e$ deleptonization that was originally added in #248.

The version that's now in phoebus is given by: $dS = -d Y_e ( \mu_e - \mu_n + \mu_p) / T$.

Since we don't actually track entropy in phoebus, I thought it would be best to do this update through primitives (e.g. updating our temperature at constant $\rho$) with the help of singularity-EOS. I took chemical potentials directly from the EOS with singularity, and then implemented a quick root find to estimate the temperature that should produce the calculated change in entropy at a constant value of $\rho$.

This does seem a bit fast and lose thermodynamically, so if people have suggestions for a better implementation they are very welcome! Figures from the tests are coming very soon.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Format your changes by calling `scripts/bash/format.sh`.
- [x] Explain what you did.
- [x] Make any necessary changes to the documentation.
